### PR TITLE
Fix channel double-close

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -32,10 +32,10 @@ func (c *Channel[T]) Subscribe(ch chan<- T) (last *T, closer func()) {
 				// Remove the channel from the slice without preserving the order
 				c.listeners[i] = c.listeners[len(c.listeners)-1]
 				c.listeners = c.listeners[:len(c.listeners)-1]
-				break
+				close(listener)
+				return
 			}
 		}
-		close(ch)
 	}
 }
 

--- a/broadcast_test.go
+++ b/broadcast_test.go
@@ -103,7 +103,7 @@ func TestBackPressureWithMultipleReceivers(t *testing.T) {
 	c2 := make(chan int)
 
 	ch.Subscribe(c1)
-	ch.Subscribe(c2)
+	_, closer2 := ch.Subscribe(c2)
 
 	ch.Publish(42)
 
@@ -115,6 +115,9 @@ func TestBackPressureWithMultipleReceivers(t *testing.T) {
 	// Check that c2 was closed due to backpressure
 	_, ok = <-c2
 	assert.False(t, ok, "Expected channel to be closed due to backpressure")
+
+	// Make sure calling the closer doesn't panic.
+	closer2()
 }
 
 func TestSubscribeWithLastValue(t *testing.T) {


### PR DESCRIPTION
Only close the channel if we find it in the listeners slice. Otherwise, it may already have been closed.

Fixes #3